### PR TITLE
Cannot run Gatling tests in "IT" scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ All you need to do to run the example is clone this repository and then in the p
 
 * `sbt test` runs the TraditionalUnitTest inside `src/test`
 * `sbt gatling:test`runs the GatlingFunSpecExample inside `src/test`
-* `sbt it:test`runs the Integration Test Example io.gatling.funspec.example.GatlingFunSpecExampleIT inside `src/it`
+* `sbt it:test`runs the Integration Test Example io.gatling.funspec.example.TraditionalUnitTestIT inside `src/it`
+* **There is no documented approach for running Gatling tests in `src/it`**
 
 Note: you need to put the `it` scope into the Ivy `projectDependencies` definition in order to make the it tests compile:
 


### PR DESCRIPTION
There isn't an obvious way to run Gatling tests as integration tests (i.e. from the `src/it` folder).

The `README.md` is currently incorrect, as running `it:test` does not run the Gatling test; only the integration test...

```
➜  gatling-funspec-demo git:(master) sbt it:test
[info] Loading project definition from /Users/lawrence/Repositories/gatling-funspec-demo/project
[info] Set current project to gatling-funspec-example (in build file:/Users/lawrence/Repositories/gatling-funspec-demo/)
[info] Updating {file:/Users/lawrence/Repositories/gatling-funspec-demo/}gatling-funspec-example...
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] Compiling 1 Scala source to /Users/lawrence/Repositories/gatling-funspec-demo/target/scala-2.11/it-classes...
[info] TraditionalUnitTestIT:
[info] Traditional unit tests
[info] - should work like they normally do
[info] Run completed in 206 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 16 s, completed 29-Nov-2016 10:06:11
➜  gatling-funspec-demo git:(master)
```